### PR TITLE
Update contributor guide to include language from the template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,33 @@ a contribution!
 
 If you end up using our library in a project, give us a star on GitHub!
 
+All contributions and project spaces are subject to our [Code of Conduct](https://github.com/fidelity/.github/blob/main/CODE_OF_CONDUCT.md).
+
+## Code Contributions
+
+- With any piece of code, please adhere to PEP-8 standards.
+- If you're fixing an issue with an existing piece of code, please make sure
+all the tests pass, and there is no change in functionality.
+- If you want to add a new feature, please open up an issue first.
+- When adding a new feature, make sure you have relevant test coverage.
+- Any changes to the public API should conform to the current standards,
+be properly documented, typed, and be intuitive.
+- Your contribution must be received under the project's open source license.
+- You must have permission to make the contribution. We strongly recommend including a Signed-off-by line to indicate your adherence to the [Developer Certificate of Origin](https://developercertificate.org/).
+- All code contributions must be made via PR, and all checks must pass before merging.
+
+## How to report a bug
+
+Please open an issue **unless** you are making a significant security disclosure.
+
+When reporting a bug, please start from a fresh pull of the default branch and document how you encountered the issue. Reports with insufficient detail and which we can't reproduce may be closed without action.
+
+While bugs can be frustrating, we ask participants to contribute positively and professionally to the discourse. While we commit to take the contents of the report seriously, abusive behavior be will not be tolerated.
+
+## How to disclose security concerns responsibly
+
+Please follow the instructions in our [security policy](https://github.com/fidelity/.github/blob/main/SECURITY.md) (also visible in the Security tab on the project's repo).
+
 ## Code Contributions
 
 - With any piece of code, please adhere to PEP-8 standards.
@@ -21,3 +48,7 @@ be properly documented, typed, and be intuitive.
 - Make sure you follow the standards set by the rest of the repo.
 - Be concise, but do not omit details. Verbose documentation is preferred to
 incomplete documentation.
+
+## Getting help
+
+If you have other questions about this project, please open an issue. To reach the Fidelity OSPO directly, please email [opensource@fmr.com](mailto:opensource@fmr.com).


### PR DESCRIPTION
Fidelity is updating and standardizing our GitHub presence. This PR adds various guidelines from the default contributor guide.

Signed-off-by: Brian Warner <brian.warner2@fmr.com>