### PR TITLE
Doc2Vec update on negative sampling

### DIFF
--- a/tests/test_doc2vec.py
+++ b/tests/test_doc2vec.py
@@ -48,9 +48,9 @@ class Doc2VecTest(BaseTest):
         """
         tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=0,
                                          hashfxn=det_hash), dtype=torch.float32)
-        expected = torch.tensor([[0.1190547720, -0.1604744494],
-                                 [-0.1089997515,  0.0665458068],
-                                 [-0.0027067859, -0.1279250085]], dtype=torch.float32)
+        expected = torch.tensor([[0.2194924355,  0.2886725068],
+                                 [-0.0268423539,  0.0644853190],
+                                 [0.1089515761, -0.0599035546]], dtype=torch.float32)
         self._test_fit_transform(tw, expected)
 
     def test_deterministic_transform(self):

--- a/tests/test_doc2vec.py
+++ b/tests/test_doc2vec.py
@@ -23,7 +23,7 @@ def det_hash(x):
 class Doc2VecTest(BaseTest):
 
     def test_fit_transform(self):
-        tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=0,
+        tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=5,
                                          hashfxn=det_hash), dtype=torch.float32)
         expected = torch.tensor([[0.1922276616,  0.2392318249],
                                  [-0.0607281923,  0.0164829195],
@@ -37,7 +37,7 @@ class Doc2VecTest(BaseTest):
         This test makes sure we can get a deterministic result when necessary.
         """
         tw = TextWiser(Embedding.Doc2Vec(deterministic=True, seed=1234, vector_size=2, min_count=1, workers=1, sample=0,
-                                         negative=0, hashfxn=det_hash), dtype=torch.float32)
+                                         negative=5, hashfxn=det_hash), dtype=torch.float32)
         expected = torch.tensor([[0.1922276616,  0.2392318249],
                                  [-0.0607281923,  0.0164829195],
                                  [0.0748119354, -0.0934505463]], dtype=torch.float32)
@@ -63,7 +63,7 @@ class Doc2VecTest(BaseTest):
             TextWiser(Embedding.Doc2Vec(tokenizer=lambda doc: [1]))
 
     def test_pretrained(self):
-        tw = TextWiser(Embedding.Doc2Vec(deterministic=True, seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=0, hashfxn=det_hash), dtype=torch.float32)
+        tw = TextWiser(Embedding.Doc2Vec(deterministic=True, seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=5, hashfxn=det_hash), dtype=torch.float32)
         expected = torch.tensor([[0.1922276616,  0.2392318249],
                                  [-0.0607281923,  0.0164829195],
                                  [0.0748119354, -0.0934505463]], dtype=torch.float32)

--- a/tests/test_doc2vec.py
+++ b/tests/test_doc2vec.py
@@ -5,6 +5,7 @@ import os
 import pickle
 from tempfile import NamedTemporaryFile
 import torch
+import unittest
 
 from textwiser import TextWiser, Embedding, device
 from tests.test_base import BaseTest, docs
@@ -30,6 +31,28 @@ class Doc2VecTest(BaseTest):
                                  [0.0748119354, -0.0934505463]], dtype=torch.float32)
         self._test_fit_transform(tw, expected)
 
+    @unittest.skip("Test fails due to downstream library behavior, Gensim")
+    def test_fit_transform_neg_0(self):
+        """
+        This test fails and will be skipped due to negative sampling value being set to 0 for Doc2Vec.
+        We must set either 'hs' (hierarchical softmax) or 'negative' to be positive for proper training.
+
+        The default values for hs and negative are 0 and 5 respectively.When both 'hs=0' and 'negative=0', there will
+        be no training.
+
+        The reason being Doc2Vec do not update word embeddings if negative keyword is set to 0.
+        So, in order to mitigate this, the contributors added a sanity check to the hs and negative arguments
+        which checks if both hs and negative are set to 0 and throws the above error.
+
+        Here is the approved PR in the Gensim Library for the above check- RaRe-Technologies/gensim#3443
+        """
+        tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=0,
+                                         hashfxn=det_hash), dtype=torch.float32)
+        expected = torch.tensor([[0.1922276616,  0.2392318249],
+                                 [-0.0607281923, 0.0164829195],
+                                 [0.0748119354, -0.0934505463]], dtype=torch.float32)
+        self._test_fit_transform(tw, expected)
+
     def test_deterministic_transform(self):
         """Specifying the `deterministic` option should make Doc2Vec transformation deterministic.
 
@@ -45,7 +68,6 @@ class Doc2VecTest(BaseTest):
         tw = TextWiser(Embedding.Doc2Vec(pretrained=None, deterministic=True, seed=1234, vector_size=2, min_count=1,
                                          workers=1, sample=0, negative=5, hashfxn=det_hash), dtype=torch.float32)
         self._test_fit_before_transform(tw, expected)
-        print('ppp')
 
 
     def test_tokenizer_validation(self):

--- a/tests/test_doc2vec.py
+++ b/tests/test_doc2vec.py
@@ -43,8 +43,9 @@ class Doc2VecTest(BaseTest):
                                  [0.0748119354, -0.0934505463]], dtype=torch.float32)
         self._test_fit_before_transform(tw, expected)
         tw = TextWiser(Embedding.Doc2Vec(pretrained=None, deterministic=True, seed=1234, vector_size=2, min_count=1,
-                                         workers=1, sample=0, negative=0, hashfxn=det_hash), dtype=torch.float32)
+                                         workers=1, sample=0, negative=5, hashfxn=det_hash), dtype=torch.float32)
         self._test_fit_before_transform(tw, expected)
+        print('ppp')
 
 
     def test_tokenizer_validation(self):

--- a/tests/test_doc2vec.py
+++ b/tests/test_doc2vec.py
@@ -26,9 +26,9 @@ class Doc2VecTest(BaseTest):
     def test_fit_transform(self):
         tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=5,
                                          hashfxn=det_hash), dtype=torch.float32)
-        expected = torch.tensor([[0.1922276616,  0.2392318249],
-                                 [-0.0607281923,  0.0164829195],
-                                 [0.0748119354, -0.0934505463]], dtype=torch.float32)
+        expected = torch.tensor([[0.2194924355,  0.2886725068],
+                                 [-0.0268423539,  0.0644853190],
+                                 [0.1089515761, -0.0599035546]], dtype=torch.float32)
         self._test_fit_transform(tw, expected)
 
     @unittest.skip("Test fails due to downstream library behavior, Gensim")
@@ -48,9 +48,9 @@ class Doc2VecTest(BaseTest):
         """
         tw = TextWiser(Embedding.Doc2Vec(seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=0,
                                          hashfxn=det_hash), dtype=torch.float32)
-        expected = torch.tensor([[0.1922276616,  0.2392318249],
-                                 [-0.0607281923, 0.0164829195],
-                                 [0.0748119354, -0.0934505463]], dtype=torch.float32)
+        expected = torch.tensor([[0.1190547720, -0.1604744494],
+                                 [-0.1089997515,  0.0665458068],
+                                 [-0.0027067859, -0.1279250085]], dtype=torch.float32)
         self._test_fit_transform(tw, expected)
 
     def test_deterministic_transform(self):
@@ -61,9 +61,9 @@ class Doc2VecTest(BaseTest):
         """
         tw = TextWiser(Embedding.Doc2Vec(deterministic=True, seed=1234, vector_size=2, min_count=1, workers=1, sample=0,
                                          negative=5, hashfxn=det_hash), dtype=torch.float32)
-        expected = torch.tensor([[0.1922276616,  0.2392318249],
-                                 [-0.0607281923,  0.0164829195],
-                                 [0.0748119354, -0.0934505463]], dtype=torch.float32)
+        expected = torch.tensor([[0.2203897089,  0.2896924317],
+                                 [-0.0264264140,  0.0707252845],
+                                 [0.1079177931, -0.0554158054]], dtype=torch.float32)
         self._test_fit_before_transform(tw, expected)
         tw = TextWiser(Embedding.Doc2Vec(pretrained=None, deterministic=True, seed=1234, vector_size=2, min_count=1,
                                          workers=1, sample=0, negative=5, hashfxn=det_hash), dtype=torch.float32)
@@ -87,9 +87,9 @@ class Doc2VecTest(BaseTest):
 
     def test_pretrained(self):
         tw = TextWiser(Embedding.Doc2Vec(deterministic=True, seed=1234, vector_size=2, min_count=1, workers=1, sample=0, negative=5, hashfxn=det_hash), dtype=torch.float32)
-        expected = torch.tensor([[0.1922276616,  0.2392318249],
-                                 [-0.0607281923,  0.0164829195],
-                                 [0.0748119354, -0.0934505463]], dtype=torch.float32)
+        expected = torch.tensor([[0.2203897089,  0.2896924317],
+                                 [-0.0264264140,  0.0707252845],
+                                 [0.1079177931, -0.0554158054]], dtype=torch.float32)
         self._test_fit_before_transform(tw, expected)
         # Test loading from bytes
         with NamedTemporaryFile() as file:

--- a/tests/test_word.py
+++ b/tests/test_word.py
@@ -132,11 +132,11 @@ class WordTest(BaseTest):
     def test_word2vec_fit(self):
         """The word2vec embeddings should be trainable from scratch."""
         tw = TextWiser(Embedding.Word(word_option=WordOptions.word2vec, pretrained=None, seed=1234, vector_size=2,
-                                      min_count=1, workers=1, sample=0, negative=0, hashfxn=self.hash),
+                                      min_count=1, workers=1, sample=0, negative=5, hashfxn=self.hash),
                        Transformation.Pool(pool_option=PoolOptions.max), dtype=torch.float32)
-        expected = torch.tensor([[0.4879405499, 0.4640791416],
-                                 [0.4879405499, 0.4766997099],
-                                 [0.4793506861, 0.4766997099]], dtype=torch.float32)
+        expected = torch.tensor([[0.4905824959, 0.4688255489],
+                                 [0.4905824959, 0.4849084020],
+                                 [0.4857406616, 0.4849084020]], dtype=torch.float32)
         self._test_fit_transform(tw, expected)
 
     def test_tokenizer_validation(self):


### PR DESCRIPTION
- Updates -
. Fixed the test cases where negative sampling was set to 0 for Doc2Vec. Updated the value with 5(default value)

- Reason for the error -
We must set either 'hs' (hierarchical softmax) or 'negative' to be positive for proper training. When both 'hs=0' and 'negative=0', there will be no training. 

The cause for the above error being Doc2Vec do not update word embeddings if negative keyword is set to 0. So, in order to mitigate this, the contributors added a sanity check to the hs and negative arguments which checks if both hs and negative are set to 0 and throws the above error.

Here is the approved PR in the Gensim Library  for the above check- https://github.com/RaRe-Technologies/gensim/pull/3443


