### PR TITLE
Fix/torch model load

### DIFF
--- a/tests/test_textwiser.py
+++ b/tests/test_textwiser.py
@@ -63,7 +63,7 @@ class TextWiserTest(BaseTest):
             model = nn.Sequential(tw, nn.Linear(2, 1)).to(device)
             # Load the model from file
             file.seek(0)
-            model.load_state_dict(torch.load(file, map_location=device))
+            model.load_state_dict(torch.load(file, map_location=device, weights_only=False))
             # Do predictions with the loaded model
             predicted = model(docs)
             self.assertTrue(torch.allclose(predicted, expected, atol=1e-6))

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -55,7 +55,7 @@ class USETest(BaseTest):
                 model = nn.Sequential(tw, nn.Linear(512, 1)).to(device)
                 # Load the model from file
                 file.seek(0)
-                model.load_state_dict(torch.load(file, map_location=device))
+                model.load_state_dict(torch.load(file, map_location=device, weights_only=False))
                 # Do predictions with the loaded model
                 predicted = model(docs)
                 self.assertTrue(torch.allclose(predicted, expected, atol=1e-6))


### PR DESCRIPTION
PyTorch 2.6 changed the default behavior of torch.load by setting weights_only=True by default (previously it was False). So, explicitly adding it to fix the test errors.

No changes to the source code, so leaving the version as it is and skipping the PyPI update.